### PR TITLE
Exposed CKAN access log for Fail2ban jail. Modified .env.template.

### DIFF
--- a/contrib/docker/.env.template
+++ b/contrib/docker/.env.template
@@ -42,4 +42,6 @@ POSTGRES_PORT=5432
 # Readwrite user/pass will be ckan:POSTGRES_PASSWORD
 # Readonly user/pass will be datastore_ro:DATASTORE_READONLY_PASSWORD
 DATASTORE_READONLY_PASSWORD=datastore
-
+#
+# Set the folder path and include the file name of the CKAN access log that will be read by Fail2ban jail.
+CKAN_LOG_PATH=/var/log/ckan_logs/ckanlog.log

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -31,6 +31,7 @@ x-ckan: &ckan_app
     - ckan_config:/etc/ckan
     - ckan_home:/usr/lib/ckan
     - ckan_storage:/var/lib/ckan
+    - ${CKAN_LOG_PATH}:/usr/lib/ckan/venv/src/ckanlog.log
 
 x-ckan_build: &ckan_build
     build:


### PR DESCRIPTION
A quick line of code to expose the CKAN access logs so Fail2ban can apply brute force protection using the ckan-soft jail. For the Fail2ban jail to be fully operational, it needs the ckan-soft.conf file and jail.local to be updated as well.