### PR TITLE
Locally exposed postgres port, to access database via ssh using datagrip/etc. for migrations

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -97,6 +97,8 @@ services:
   db:
     container_name: db
     image: docker_db
+    ports:
+       - "5432:5432"
     build:
       context: ../../
       dockerfile: contrib/docker/postgresql/Dockerfile


### PR DESCRIPTION
During our CKAN dev/prod migration process it is beneficial to allow local postgres docker container port access only (not exposed to the public), to move database tables such as the users table to maintain the same passwords between dev and prod. Our ports are closed at the VM level, so with our setup this only allows access via ssh-key tunnel, and db password. I'm using DataGrip to manage this database, and find this helpful operationally as well.