### PR TITLE
add dataset page organization visibility config options 

### DIFF
--- a/INSTALL_CIOOS_CKAN.md
+++ b/INSTALL_CIOOS_CKAN.md
@@ -931,6 +931,27 @@ background:rgb(185, 214, 242);
 }
 ```
 
+
+### reset runtime edited config settings
+
+connect to db
+```bash
+sudo docker exec -u root -it db psql -U ckan
+```
+
+delete appropreit records. Some example field names are: `ckan.site_title`, `ckan.header_file_name`, or  `ckan.hide_organization_in_dataset_sidebar`
+```sql
+delete from public.system_info_revision where key = 'your_config_field_name';
+delete from public.system_info where key = 'your_config_field_name';
+exit
+```
+
+restart ckan
+```bash
+cd ~/ckan/contrib/docker
+sudo docker-compose restart ckan
+```
+
 ## Enable Google Analytics
 
 edit the **production.ini** file currently in the volume.

--- a/contrib/docker/production_non_root_url.ini
+++ b/contrib/docker/production_non_root_url.ini
@@ -140,6 +140,12 @@ ckan.plugins = stats
               geojson_view
               wmts_view
 
+# ckan.show_social_in_dataset_sidebar = false
+# ckan.hide_organization_in_breadcrumb = false
+# ckan.hide_organization_in_dataset_sidebar = false
+# ckan.show_responsible_organization_in_dataset_sidebar = false
+
+
 ckanext.geoview.ol_viewer.formats = wms kml wfs geojson gml kml arcgis_rest
 ckanext.geoview.ol_viewer.hide_overlays: false
 ckanext.geoview.ol_viewer.default_feature_hoveron: true

--- a/contrib/docker/production_root_url.ini
+++ b/contrib/docker/production_root_url.ini
@@ -140,6 +140,11 @@ ckan.plugins = stats
               geojson_view
               wmts_view
 
+# ckan.show_social_in_dataset_sidebar = false
+# ckan.hide_organization_in_breadcrumb = false
+# ckan.hide_organization_in_dataset_sidebar = false
+# ckan.show_responsible_organization_in_dataset_sidebar = false
+
 ckanext.geoview.ol_viewer.formats = wms kml wfs geojson gml kml arcgis_rest
 ckanext.geoview.ol_viewer.hide_overlays: false
 ckanext.geoview.ol_viewer.default_feature_hoveron: true


### PR DESCRIPTION
Depends on cioos-siooc/ckanext-cioos_theme#36

document how to remove a runtime edited config setting from the database so that the setting in produciton.ini will be used.