### PR TITLE
Migrated log creation commands from ckan-entrypoint.sh to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,6 +212,10 @@ COPY --from=cioos_extensions $CKAN_VENV/lib/python2.7/site-packages/ $CKAN_VENV/
 
 RUN /bin/bash -c "sort -u $CKAN_VENV/lib/python2.7/site-packages/easy-install-[ABCD].pth > $CKAN_VENV/lib/python2.7/site-packages/easy-install.pth"
 
+RUN mkdir -p $CKAN_VENV/src/logs
+RUN touch "$CKAN_VENV/src/logs/ckan_access.log"
+RUN touch "$CKAN_VENV/src/logs/ckan_default.log"
+
 RUN  chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
 
 ENTRYPOINT ["/ckan-entrypoint.sh"]

--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -68,15 +68,6 @@ if [ -z "$CKAN_DATAPUSHER_URL" ]; then
     abort "ERROR: no CKAN_DATAPUSHER_URL specified in docker-compose.yml"
 fi
 
-# create log files
-if [ ! -f "$CKAN_LOG_PATH/ckan_access.log" ]; then
-    touch "$CKAN_LOG_PATH/ckan_access.log"
-fi
-if [ ! -f "$CKAN_LOG_PATH/ckan_default.log" ]; then
-    touch "$CKAN_LOG_PATH/ckan_default.log"
-fi
-
-
 set_environment
 ckan-paster --plugin=ckan db init -c "${CKAN_CONFIG}/production.ini"
 ckan-paster --plugin=ckanext-harvest harvester initdb -c "${CKAN_CONFIG}/production.ini"


### PR DESCRIPTION
Fixes #74 

moved log file touch calls from ckan-entrypoint.sh to Dockerfile which gets around permission and access to environmental variable issues preventing the ckan container from spinning up.