### PR TITLE
Add roles specific responsible organisations

### DIFF
--- a/contrib/docker/.env.template
+++ b/contrib/docker/.env.template
@@ -160,8 +160,20 @@ CKAN__SEARCH__SOLR_ALLOWED_QUERY_PARSERS = frange
 #
 # CIOOS
 CKAN__CIOOS__RA_CSS_PATH = /CHANGE_ME.css
-CKAN__HARVEST_RESPONSIBLE_ORGANIZATIONS = True 
-# CKAN__RESPONSIBLE_ORGANIZATION_ROLES = ["owner", "originator", "author", "principalInvestigator"]
+
+# CIOOS Harvest - Responsible Organization Settings
+# Enable/disable responsible organization harvesting
+CKAN__HARVEST_RESPONSIBLE_ORGANIZATIONS = True
+
+# Contact roles from cited-responsible-party to associate with responsible organizations
+# Default: ["owner", "originator", "custodian", "author", "principalInvestigator"]
+CKAN__RESPONSIBLE_ORGANIZATION_ROLES = ["owner", "originator", "custodian", "author", "principalInvestigator"]
+
+# Additional contact roles from metadata-point-of-contact (or other sources) to associate with responsible organizations
+# This allows including organizations that are not in the citation but have important roles
+# Default: [] (empty list)
+# Uncomment and customize as needed:
+# CKAN__ADDITIONAL_RESPONSIBLE_ORGANIZATION_ROLES = ["pointOfContact", "distributor", "resourceProvider"]
 
 # to use amazone translate you must have the following AWS keys set
 # user found at https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/cioos-metadata-form-translate-only?section=permissions

--- a/contrib/docker/production_root_url.ini
+++ b/contrib/docker/production_root_url.ini
@@ -151,6 +151,20 @@ ckan.harvest.log_level = info
 ckanext.harvest.default_dataset_name_append = number-sequence
 ckan.harvest.status_mail.errored = True
 
+## CIOOS Harvest Settings
+# Enable/disable responsible organization harvesting
+ckan.harvest_responsible_organizations = true
+
+# Contact roles from cited-responsible-party to associate with responsible organizations
+# Default: ["owner", "originator", "custodian", "author", "principalInvestigator"]
+ckan.responsible_organization_roles = ["owner", "originator", "custodian", "author", "principalInvestigator"]
+
+# Additional contact roles from metadata-point-of-contact (or other sources) to associate with responsible organizations
+# This allows including organizations that are not in the citation but have important roles
+# Default: [] (empty list)
+# Example: ["pointOfContact", "distributor", "resourceProvider"]
+ckan.additional_responsible_organization_roles = []
+
 scheming.composite.separator = |
 
 


### PR DESCRIPTION
This pull request introduces new configuration options for controlling how responsible organizations are harvested and associated based on contact roles in the CKAN harvest process. These changes provide more granular control over which organizations are recognized as responsible, with options to customize the roles considered and to include additional roles from various metadata sources.

Harvesting configuration enhancements:

* Added new environment variables (`CKAN__HARVEST_RESPONSIBLE_ORGANIZATIONS`, `CKAN__RESPONSIBLE_ORGANIZATION_ROLES`, and optional `CKAN__ADDITIONAL_RESPONSIBLE_ORGANIZATION_ROLES`) to `contrib/docker/.env.template` for enabling/disabling responsible organization harvesting and specifying which contact roles to use.
* Updated `contrib/docker/production_root_url.ini` to include corresponding configuration settings for responsible organization harvesting and role customization, with clear defaults and documentation.

Submodule update:

* Updated the `ckanext-cioos_harvest` submodule to a newer commit, potentially bringing in related improvements or bug fixes.