### PR TITLE
Update Dockerfile to install urllib3 version 2.0 or higher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN --mount=type=cache,target=/root/.cache/pip apk add --no-cache .build-deps li
     && pip3 install gdal==3.4.3 --no-cache-dir \
     && pip3 install ckanapi --no-cache-dir \
     && pip3 install -U requests[security] --no-cache-dir \
+    && pip3 install -U 'urllib3>=2.0' --no-cache-dir \
     # for debugging
     && pip3 install 'flask_debugtoolbar==0.14.1' --no-cache-dir \
     # clean up


### PR DESCRIPTION
This pull request makes a small update to the dependencies installed in the `Dockerfile`. The most important change is the addition of an explicit installation of a newer version of `urllib3` (version 2.0 or higher) using pip.

* Added installation of `urllib3>=2.0` to ensure the container uses an up-to-date version of this library for improved security and compatibility.