### PR TITLE
Add build arguments for CKAN Docker images and set default tag

### DIFF
--- a/.github/workflows/ckan-docker-image-daily.yml
+++ b/.github/workflows/ckan-docker-image-daily.yml
@@ -78,6 +78,8 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          CIOOS_CKAN_TAG=${{env.TAG}}
         tags: |
           cioos/ckan:${{env.TAG}}
 
@@ -89,6 +91,8 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          CIOOS_CKAN_TAG=${{env.TAG}}
         tags: |
           cioos/ckan:latest
           cioos/ckan:${{env.TAG}}

--- a/.github/workflows/ckan-docker-image-dev.yml
+++ b/.github/workflows/ckan-docker-image-dev.yml
@@ -68,6 +68,8 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          CIOOS_CKAN_TAG=DEV_${{env.TAG}}
         tags: |
           cioos/ckan:DEV_${{env.TAG}}
 
@@ -79,6 +81,8 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          CIOOS_CKAN_TAG=DEV_${{env.TAG}}
         tags: |
           cioos/ckan:DEV_latest
           cioos/ckan:DEV_${{env.TAG}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,9 @@ RUN mkdir -p $APP_DIR/logs
 RUN touch "$APP_DIR/logs/ckan_access.log"
 RUN touch "$APP_DIR/logs/ckan_default.log"
 
+ARG CIOOS_CKAN_TAG=local-build
+ENV CIOOS_CKAN_TAG=${CIOOS_CKAN_TAG}
+
 RUN chown -R 92:92 $APP_DIR $CKAN_STORAGE_PATH
 
 WORKDIR $APP_DIR


### PR DESCRIPTION
This pull request updates the Docker build and deployment process for the CKAN application by introducing a new build argument to track the build tag in the Docker image, and by updating a submodule reference. The main goal is to make the build tag available inside the Docker container and ensure the correct tag is used in different environments (daily, dev, and local builds).

**Docker build process improvements:**

* Added the `CIOOS_CKAN_TAG` build argument to the Docker build steps in both the daily and dev GitHub Actions workflows (`.github/workflows/ckan-docker-image-daily.yml`, `.github/workflows/ckan-docker-image-dev.yml`). This argument is set to the appropriate tag for each build type, making the tag available within the Docker image. [[1]](diffhunk://#diff-b5e09b54ab63a5677207ca20d17b5e0e82efc609488443e7e5c335653b0b8196R81-R82) [[2]](diffhunk://#diff-b5e09b54ab63a5677207ca20d17b5e0e82efc609488443e7e5c335653b0b8196R94-R95) [[3]](diffhunk://#diff-94e5ff3d99de6de48f88316174bee68fd1f4ae4fdba4080bba767ba9b01f36c4R71-R72) [[4]](diffhunk://#diff-94e5ff3d99de6de48f88316174bee68fd1f4ae4fdba4080bba767ba9b01f36c4R84-R85)
* Updated the `Dockerfile` to accept the `CIOOS_CKAN_TAG` build argument and set it as an environment variable, defaulting to `local-build` if not specified.

**Submodule update:**

* Updated the `ckanext-cioos_theme` submodule to a newer commit, which may include additional bug fixes or features.
   * cioos-ckan tag in login user section
   * add allow /(en/|fr/)datasets/*.(xml...) in robots.txt
   * fix jsonld schemaorg output generation 