### PR TITLE
Update cioos-siooc-schema submodule reference

### DIFF
--- a/contrib/docker/docker-compose.forms.yml
+++ b/contrib/docker/docker-compose.forms.yml
@@ -1,0 +1,14 @@
+services:
+  forms:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "${FORMS_PORT:-8080}:80"
+    volumes:
+      - ./forms:/usr/share/nginx/html:ro
+      - ./nginx/forms.conf:/etc/nginx/conf.d/default.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost/ || exit 1"]
+      interval: 60s
+      timeout: 5s
+      retries: 3

--- a/contrib/docker/nginx/forms.conf
+++ b/contrib/docker/nginx/forms.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    location / {
+        autoindex on;
+        autoindex_exact_size off;
+        autoindex_localtime on;
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
Bumps the `cioos-siooc-schema` submodule from `ffb723fc` to `dc3d3eee`, picking up:

- fix alternative_ids formatting for subsurface terms
